### PR TITLE
(ui, coc, languages, plugins): Refresh a bunch of stuff!

### DIFF
--- a/coc-settings.json
+++ b/coc-settings.json
@@ -12,5 +12,15 @@
   "pyright.inlayHints.variableTypes": false,
   "python.linting.flake8Enabled": true,
   "python.linting.mypyEnabled": false,
-  "solargraph.diagnostics": true
+  "solargraph.diagnostics": true,
+  "inlayHint.filetypes": [],
+  "rust-analyzer.inlayHints.bindingModeHints.enable": false,
+  "rust-analyzer.inlayHints.chainingHints.enable": false,
+  "rust-analyzer.inlayHints.closingBraceHints.enable": false,
+  "rust-analyzer.inlayHints.closingBraceHints.minLines": 25,
+  "rust-analyzer.inlayHints.closureReturnTypeHints.enable": false,
+  "rust-analyzer.inlayHints.discriminantHints.enable": false,
+  "rust-analyzer.inlayHints.expressionAdjustmentHints.enable": false,
+  "rust-analyzer.inlayHints.typeHints.enable": false,
+  "rust-analyzer.inlayHints.typeHints.hideNamedConstructor": true
 }

--- a/init.vim
+++ b/init.vim
@@ -1,5 +1,6 @@
 set rtp+=/usr/local/opt/fzf
 call plug#begin('~/.config/nvim/plugged')
+
 " Tooling
 Plug 'w0rp/ale'
 Plug 'junegunn/fzf', { 'do': { -> fzf#install() } }
@@ -9,29 +10,53 @@ Plug 'neoclide/coc.nvim', {'branch': 'release'}
 " Editor helpers
 Plug 'scrooloose/nerdcommenter'
 Plug 'valloric/MatchTagAlways'
-Plug 'Yggdroot/indentLine'
 " UI
-Plug 'vim-airline/vim-airline'
-Plug 'vim-airline/vim-airline-themes'
 Plug 'airblade/vim-gitgutter'
 Plug 'scrooloose/nerdtree'
-" Language-specific tooling & plugins
+Plug 'nvim-lualine/lualine.nvim'
+Plug 'nvim-tree/nvim-web-devicons'
+Plug 'marko-cerovac/material.nvim'
+Plug 'lukas-reineke/indent-blankline.nvim'
+" Languages
+Plug 'prisma/vim-prisma'
 Plug 'prettier/vim-prettier', { 'do': 'yarn install' }
 Plug 'psf/black', { 'branch': 'stable' }
 Plug 'fatih/vim-go', { 'do': ':GoUpdateBinaries' }
-" Languages (syntaxes, ...)
 Plug 'elixir-editors/vim-elixir'
 Plug 'elzr/vim-json'
 Plug 'rust-lang/rust.vim'
 Plug 'HerringtonDarkholme/yats.vim'
 Plug 'Glench/Vim-Jinja2-Syntax'
+Plug 'tpope/vim-markdown'
 call plug#end()
+
+" -----------------------------------------------------------------------------
+" Lua
+" -----------------------------------------------------------------------------
+lua << EOF
+local lualine = require 'lualine'
+local material = require 'material'
+
+lualine.setup{
+    options = {
+        theme = 'auto'
+    }
+}
+
+material.setup{
+    lualine_style = 'stealth',
+    plugins = {
+        'indent-blankline'
+    }
+}
+EOF
 
 " -----------------------------------------------------------------------------
 " Basics
 " -----------------------------------------------------------------------------
 syntax on
-colorscheme ayu
+let g:material_style = "darker"
+colorscheme material
 set termguicolors
 set encoding=utf-8
 set number
@@ -62,9 +87,9 @@ set shiftwidth=4
 " set foldlevel=1
 " set foldnestmax=10
 
+" Filetype-specific tab width
 " Parse all HTML as Jinja templates
-autocmd BufNewFile,BufRead *.html set filetype=htmldjango
-" Filetype specific tab width
+" autocmd BufNewFile,BufRead *.html set filetype=htmldjango
 autocmd Filetype python setlocal ts=4 sw=4 sts=4 expandtab
 autocmd Filetype javascript setlocal ts=2 sw=2 sts=2 expandtab
 autocmd Filetype typescript setlocal ts=2 sw=2 sts=2 expandtab
@@ -78,13 +103,15 @@ autocmd Filetype jinja.html setlocal ts=2 sw=2 sts=2 expandtab
 autocmd Filetype htmldjango setlocal ts=2 sw=2 sts=2 expandtab
 autocmd Filetype go setlocal ts=4 sw=4 sts=0  " use tabs for Go
 
-" Paths for neovim Python providers
+" Workaround some paste issue (https://github.com/neovim/neovim/issues/7994)
+au InsertLeave * set nopaste
+
+" Paths to neovim Python providers
 let g:python_host_prog=$HOME."/.pyenv/versions/nvim-py2-provider/bin/python"
 let g:python3_host_prog=$HOME."/.pyenv/versions/nvim-py3-provider/bin/python"
 
-" Workaround for paste issue
-" https://github.com/neovim/neovim/issues/7994
-au InsertLeave * set nopaste
+" Trim whitespace on :w
+autocmd BufWritePre * :call TrimWhitespace()
 
 " -----------------------------------------------------------------------------
 " Keymaps
@@ -107,11 +134,12 @@ nnoremap <silent> K :call <SID>ShowDocumentation()<CR>
 " -----------------------------------------------------------------------------
 let $FZF_DEFAULT_COMMAND = 'rg --files --hidden'
 let g:vim_json_syntax_conceal = 0
-let g:indentLine_char = '┆'
 let NERDTreeShowHidden=1
 let NERDSpaceDelims=1
 
+" -----------------------------------------------------------------------------
 " Linting/completions
+" -----------------------------------------------------------------------------
 let g:ale_completion_enabled = 0  " Disable ale completion
 let g:ale_echo_msg_format = '%linter% :: %s'
 let g:ale_statusline_format = ['⨉ %d', '⚠ %d', '⬥ ok']
@@ -119,10 +147,8 @@ let g:ale_linters_explicit = 1  " Only run linters defined in `ale_linters`
 let g:ale_linters = {
 \   'php': ['phpcs', 'phpstan'],
 \   'go': ['golint', 'govet'],
-\   'rust': ['cargo', 'analyzer'],
 \}
 let g:ale_fixers = {
-\   'rust': ['rustfmt'],
 \   'php': ['phpcbf'],
 \ }
 
@@ -130,32 +156,17 @@ let g:ale_fixers = {
 let g:ale_php_phpstan_executable = "vendor/bin/phpstan"
 let g:ale_php_phpstan_level = "8"
 
-" vim-airline
-let g:airline_theme='bubblegum'
-let g:airline#extensions#ale#enabled = 1
-let g:airline_mode_map = {
-  \ '__' : '-',
-  \ 'n'  : 'N',
-  \ 'i'  : 'I',
-  \ 'R'  : 'R',
-  \ 'c'  : 'C',
-  \ 'v'  : 'V',
-  \ 'V'  : 'V',
-  \ '' : 'V',
-  \ 's'  : 'S',
-  \ 'S'  : 'S',
-  \ '' : 'S',
-  \ 't'  : 'T',
-  \ }
-
 " coc
-nnoremap <silent> <space>t :<C-u>CocCommand metals.tvp<CR>
 nmap <silent> gd :call CocAction('jumpDefinition', 'vsplit')<CR>
 
 " -----------------------------------------------------------------------------
-" Definitions
+" Commands
 " -----------------------------------------------------------------------------
+command Fmtjson :%!jq '.'
 
+" -----------------------------------------------------------------------------
+" Functions
+" -----------------------------------------------------------------------------
 " Trim whitespace from file on write
 fun! TrimWhitespace()
     let l:save = winsaveview()
@@ -171,13 +182,3 @@ fun! s:ShowDocumentation()
     call CocAction('doHover')
   endif
 endfun
-
-" -----------------------------------------------------------------------------
-" Commands
-" -----------------------------------------------------------------------------
-command Fmtjson :%!jq '.'
-autocmd BufWritePre * :call TrimWhitespace()
-
-" Auto-run `prettier` on save. Uncomment to enable:
-" let g:prettier#autoformat = 0
-" autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html Prettier


### PR DESCRIPTION
* Switches colorscheme to [`material`](https://github.com/marko-cerovac/material.nvim) (...after 5 years!)
  * Replaces `vim-airline` with `lualine`
  * Replaces `Yggdroot/indentLine` with [`lukas-reineke/indent-blankline.nvim`](https://github.com/lukas-reineke/indent-blankline.nvim)
* Deprecated Rust on ALE in favor of LSP & associated config
* Add `vim-markdown`
* Add `vim-prisma`
* Add Lua config section
* Remove `coc-metals`
* Small reorganizing of code sections